### PR TITLE
fix flex layout in main view.

### DIFF
--- a/src/ui-components/layout/main.scss
+++ b/src/ui-components/layout/main.scss
@@ -1,5 +1,5 @@
 .main{
   width: 100%;
   height: calc(100vh - 45px - 24px);
-
+  display: flex;
 }


### PR DESCRIPTION
## Overview
When I was using this wonderful product in Google Chrome, I saw that the layout was broken, and the same thing happened in IE. Then, we added 'display: flex' to main.scss and arranged the layout.

## Tool version
mac OS Catalina: v10.15.7
Google Chrome: 87.0.4280.6

## Before
![localhost_8888_explorer](https://user-images.githubusercontent.com/24284232/100627784-c5063380-336a-11eb-8ebb-4b645e7fdd23.png)

## After
![localhost_8888_explorer (1)](https://user-images.githubusercontent.com/24284232/100627871-e9621000-336a-11eb-8970-d3c210baaa51.png)

Thank you for developing a great product. I want to contribute as much as possible!
